### PR TITLE
Changed metadata description for consistency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: John Freeman
-  description: Role for downloading and installing the Go language SDK.
+  description: Role for installing the Go language SDK.
   company: GantSign Ltd.
   license: MIT
   min_ansible_version: 2.0


### PR DESCRIPTION
Changed the role metadata to make the description consistent with other GantSign roles.