### PR TITLE
Added support for Go 1.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ configuration (for other versions follow the Advanced Configuration
 instructions):
 
 * `1.9`
+* `1.8.4`
 * `1.8.3`
 * `1.8.2`
 * `1.8.1`

--- a/vars/versions/1.8.4.yml
+++ b/vars/versions/1.8.4.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '0ef737a0aff9742af0f63ac13c97ce36f0bbc8b67385169e41e395f34170944f'


### PR DESCRIPTION
Go 1.9 will remain the default version installed.