### PR TITLE
AD-HOC feat (ansible_managed): Introduce support for multiline ansibl…

### DIFF
--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment('plain') }}
 
 [general]
 version={{ golang_version }}

--- a/templates/golang.sh.j2
+++ b/templates/golang.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# {{ ansible_managed }}
+{{ ansible_managed | comment('plain') }}
 
 export GOROOT='{{ golang_install_dir }}'
 export PATH=$PATH:$GOROOT/bin


### PR DESCRIPTION
…e_managed

In the project in which this is being implemented, the ansible_managed
phrase spans over multiple lines. It explains that changes will not be
persisted, and where to find the ansible repository.

However, in the case of the templates generated here, the comment is
only applied to the first line of ansible managed. Accordingly, it
introduces various syntax errors, particularly in `/etc/profile.d/`.
This commmit uses the `comment` filter, introduced with Ansible, to
prefix all lines with a `#` character (or, the 'plain' filter).

Tested in the environment in which it previously failed.