### PR TITLE
Added support for Go 1.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ configuration (for other versions follow the Advanced Configuration
 instructions):
 
 * `1.10`
+* `1.9.5`
 * `1.9.4`
 * `1.9.3`
 * `1.9.2`

--- a/vars/versions/1.9.5.yml
+++ b/vars/versions/1.9.5.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'd21bdabf4272c2248c41b45cec606844bdc5c7c04240899bde36c01a28c51ee7'


### PR DESCRIPTION
Go 1.10 will remain the default version installed.