### PR TITLE
Added support for Go 1.9.7

### DIFF
--- a/vars/versions/1.9.7.yml
+++ b/vars/versions/1.9.7.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '88573008f4f6233b81f81d8ccf92234b4f67238df0f0ab173d75a302a1f3d6ee'


### PR DESCRIPTION
Go 1.10.2 will remain the default version installed.