### PR TITLE
Resolved zypper module syntax deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,11 +38,10 @@
 - name: install unarchive dependencies (zypper)
   become: yes
   zypper:
-    name: '{{ item }}'
+    name:
+      - gzip
+      - tar
     state: present
-  with_items:
-    - gzip
-    - tar
   when: ansible_pkg_mgr == 'zypper'
 
 - name: install Go language SDK


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "zypper" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'gzip', u'tar']` and
remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```