### PR TITLE
Added support for Go 1.11.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ configuration (for other versions follow the Advanced Configuration
 instructions):
 
 * `1.12`
+* `1.11.6`
 * `1.11.5`
 * `1.11.4`
 * `1.11.3`

--- a/vars/versions/1.11.6.yml
+++ b/vars/versions/1.11.6.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49'


### PR DESCRIPTION
Go 1.12 will remain the default version installed.