### PR TITLE
Updated Go to 1.12.4; added support for 1.11.[89], 1.12.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ are shown below):
 
 ```yaml
 # Go language SDK version number
-golang_version: '1.12.2'
+golang_version: '1.12.4'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'
@@ -75,9 +75,13 @@ The following versions of Go language SDK are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `1.12.4`
+* `1.12.3`
 * `1.12.2`
 * `1.12.1`
 * `1.12`
+* `1.11.9`
+* `1.11.8`
 * `1.11.7`
 * `1.11.6`
 * `1.11.5`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Go language SDK version number
-golang_version: '1.12.2'
+golang_version: '1.12.4'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -9,9 +9,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.12.2$'),
+    ('GOROOT', '^/opt/go/1.12.4$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.12.2/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.12.4/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.11.8.yml
+++ b/vars/versions/1.11.8.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1'

--- a/vars/versions/1.11.9.yml
+++ b/vars/versions/1.11.9.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608'

--- a/vars/versions/1.12.3.yml
+++ b/vars/versions/1.12.3.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df'

--- a/vars/versions/1.12.4.yml
+++ b/vars/versions/1.12.4.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'd7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5'


### PR DESCRIPTION
There were a bunch of releases right in a row; it didn't seem worth it (to me) to add them in as separate commits, but feel free to use or discard this pull request as you see fit.