### PR TITLE
Added support for Go 1.12.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ configuration (for other versions follow the Advanced Configuration
 instructions):
 
 * `1.13`
+* `1.12.10`
 * `1.12.9`
 * `1.12.8`
 * `1.12.7`

--- a/molecule/ubuntu-max-go-eol/playbook.yml
+++ b/molecule/ubuntu-max-go-eol/playbook.yml
@@ -4,5 +4,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.12.9'
+      golang_version: '1.12.10'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -9,9 +9,9 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.12.9$'),
+    ('GOROOT', '^/opt/go/1.12.10$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.12.9/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.12.10/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.12.10.yml
+++ b/vars/versions/1.12.10.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'aaa84147433aed24e70b31da369bb6ca2859464a45de47c2a5023d8573412f6b'


### PR DESCRIPTION
Go 1.13 remains the default version installed.