### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 
         * Ubuntu
 
-            * Trusty (14.04)
             * Xenial (16.04)
             * Bionic (18.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,6 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
     - name: Debian

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-golang-ubuntu-min
-    image: ubuntu:14.04
+    image: ubuntu:16.04
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Trusty (14.04).