### PR TITLE
Fixed sha256 for 1.14.1 arm64

### DIFF
--- a/vars/versions/1.14.1-aarch64.yml
+++ b/vars/versions/1.14.1-aarch64.yml
@@ -1,3 +1,3 @@
 ---
 # SHA256 sum for the redistributable package
-golang_redis_sha256sum: '2f49eb17ce8b48c680cdb166ffd7389702c0dec6effa090c324804a5cac8a7f8'
+golang_redis_sha256sum: '5d8f2c202f35481617e24e63cca30c6afb1ec2585006c4a6ecf16c5f4928ab3c'


### PR DESCRIPTION
Was using the amd64 sha256 by mistake.