### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: Go language SDK
 =============================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-golang.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-golang)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-golang.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-golang)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.golang-blue.svg)](https://galaxy.ansible.com/gantsign/golang)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-golang/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.