### PR TITLE
Add support for current gloang releases on 32bit RPiOS

### DIFF
--- a/vars/main-armv7l.yml
+++ b/vars/main-armv7l.yml
@@ -1,0 +1,3 @@
+---
+# Filename of Go language SDK redistributable package
+golang_redis_filename: 'go{{ golang_version }}.linux-armv6l.tar.gz'

--- a/vars/versions/1.14.10-armv71.yml
+++ b/vars/versions/1.14.10-armv71.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'b601dbb186d786488470d73d4637c2144896bf6f499a4122bdd30f4e8dd79e70'

--- a/vars/versions/1.15.3-armv7l.yml
+++ b/vars/versions/1.15.3-armv7l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'aacb49968d08e222c83dea7307b4523c3ae498a5d2e91cd0e480ef3f198ffef6'


### PR DESCRIPTION
RPiOS 32bit reports ansible_architecture as armv7l, which requires golang linux-armv6l builds. Tested on a Raspberry Pi 4b.

I've not updated the README because I didn't know what you'd want to add there. I saw there was a previous PR which added support for all versions for arm64, which means the Advanced Configuration section could be changed because that example doesn't need to be for arm64 anymore as that's natively supported.