### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,7 +18,6 @@ galaxy_info:
       versions:
         - buster
         - stretch
-        - jessie
     - name: Fedora
       versions:
         - 31

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-golang-debian-min
-    image: debian:8
+    image: debian:9
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Ansible 2.10 requires Python 3.5