### PR TITLE
Increased minimum Ansible version to 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             ansible-version: '2.9.1'
             molecule-scenario: ubuntu-arm64v8
           - architecture: amd64
-            ansible-version: '2.8.16'
+            ansible-version: '2.9.18'
             molecule-scenario: default
 
     env:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role to download and install the [Go language SDK](https://golang.org/).
 Requirements
 ------------
 
-* Ansible >= 2.8
+* Ansible >= 2.9
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing the Go language SDK.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.9.