### PR TITLE
Added support for Go 1.16.7

### DIFF
--- a/molecule/ubuntu-max-go-eol/converge.yml
+++ b/molecule/ubuntu-max-go-eol/converge.yml
@@ -4,5 +4,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.15.15'
+      golang_version: '1.16.7'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.15.15$'),
+    ('GOROOT', '^/opt/go/1.16.7$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.15.15/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.16.7/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):


### PR DESCRIPTION
Go 1.17 remains the default version installed.