### PR TITLE
Upgraded minimum Ansible test version to 2.9.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             ansible-version: '2.10.7' # max-ansible-test-version
             molecule-scenario: ubuntu-arm64v8
           - architecture: amd64
-            ansible-version: '2.9.18' # min-ansible-test-version
+            ansible-version: '2.9.26' # min-ansible-test-version
             molecule-scenario: default
 
     env:


### PR DESCRIPTION
For Python 3.8 compatibility.