### PR TITLE
Updated Go to 1.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ are shown below):
 
 ```yaml
 # Go language SDK version number
-golang_version: '1.18.2'
+golang_version: '1.18.3'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'
@@ -75,6 +75,7 @@ The following versions of Go language SDK are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `1.18.3`
 * `1.18.2`
 * `1.18.1`
 * `1.18`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Go language SDK version number
-golang_version: '1.18.2'
+golang_version: '1.18.3'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.18.2$'),
+    ('GOROOT', '^/opt/go/1.18.3$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.18.2/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.18.3/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.18.3-arm64.yml
+++ b/vars/versions/1.18.3-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'beacbe1441bee4d7978b900136d1d6a71d150f0a9bb77e9d50c822065623a35a'

--- a/vars/versions/1.18.3-armv6l.yml
+++ b/vars/versions/1.18.3-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'b8f0b5db24114388d5dcba7ca0698510ea05228b0402fcbeb0881f74ae9cb83b'

--- a/vars/versions/1.18.3.yml
+++ b/vars/versions/1.18.3.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '956f8507b302ab0bb747613695cdae10af99bbd39a90cae522b7c0302cc27245'


### PR DESCRIPTION
1.18.3 will now be installed by default.