### PR TITLE
Updated EOL tests to Go 1.18.5

### DIFF
--- a/molecule/ubuntu-max-go-eol/converge.yml
+++ b/molecule/ubuntu-max-go-eol/converge.yml
@@ -4,5 +4,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.17.13'
+      golang_version: '1.18.5'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.17.13$'),
+    ('GOROOT', '^/opt/go/1.18.5$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.17.13/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.18.5/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):


### PR DESCRIPTION
Go 1.19 remains the default version installed.