### PR TITLE
Dropped support for Debian Stretch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         molecule-scenario:
           - rocky
           - debian-max
-          # - debian-min
+          - debian-min
           - default
           - ubuntu-min
           - fedora

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Stretch (9)
             * Buster (10)
             * Bullseye (11)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
     - name: Debian
       versions:
         - buster
-        - stretch
         - bullseye
     - name: Fedora
       versions:

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-golang-debian-min
-    image: debian:9
+    image: debian:10
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian standard support ended on 01 Jul 2022.