### PR TITLE
Fix link to galaxy and role name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - role: gantsign.golang
+     - role: gantsign.ansible-role-golang
        golang_gopath: '$HOME/workspace-go'
 ```
 
@@ -289,7 +289,7 @@ More Roles From GantSign
 ------------------------
 
 You can find more roles from GantSign on
-[Ansible Galaxy](https://galaxy.ansible.com/gantsign).
+[Ansible Galaxy](https://galaxy.ansible.com/ui/standalone/namespaces/2463/).
 
 Development & Testing
 ---------------------


### PR DESCRIPTION
Since 3.2.2 the role is published under a different name on Galaxy. It's not mentioned in the release notes, so I'm not sure that's intentional.

I also updated the link to the role catalog.