### PR TITLE
Added support for Go 1.21.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ configuration (for other versions follow the Advanced Configuration
 instructions):
 
 * `1.22.0`
+* `1.21.7`
 * `1.21.6`
 * `1.21.5`
 * `1.21.4`

--- a/molecule/ubuntu-max-go-eol/converge.yml
+++ b/molecule/ubuntu-max-go-eol/converge.yml
@@ -5,5 +5,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.20.13'
+      golang_version: '1.21.7'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.20.13$'),
+    ('GOROOT', '^/opt/go/1.21.7$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.20.13/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.21.7/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.21.7-arm64.yml
+++ b/vars/versions/1.21.7-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'a9bc1ccedbfde059f25b3a2ad81ae4cdf21192ae207dfd3ccbbfe99c3749e233'

--- a/vars/versions/1.21.7-armv6l.yml
+++ b/vars/versions/1.21.7-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'd86d2da4cad1c0ff5fc13677b0b77f26ca8adca48170c140f06b882e83b6e8df'

--- a/vars/versions/1.21.7.yml
+++ b/vars/versions/1.21.7.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '13b76a9b2a26823e53062fa841b07087d48ae2ef2936445dc34c4ae03293702c'


### PR DESCRIPTION
Go 1.22.0 remains the default version installed.