### PR TITLE
Increased upper Debian test version to Bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Requirements
 
             * Buster (10)
             * Bullseye (11)
+            * Bookworm (12)
 
         * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+        - bookworm
     - name: Fedora
       versions:
         - '35'

--- a/molecule/debian-max/molecule.yml
+++ b/molecule/debian-max/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-golang-debian-max
-    image: debian:11
+    image: debian:12
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Bookworm is the latest stable version of Debian.