### PR TITLE
Changed openSUSE tests to use Tumbleweed

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Requirements
 
         * openSUSE
 
-            * 15.5
+            * Tumbleweed
 
     * Note: other versions are likely to work but have not been tested.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,7 +25,7 @@ galaxy_info:
         - '40'
     - name: opensuse
       versions:
-        - '15.5'
+        - all
   galaxy_tags:
     - golang
     - development

--- a/molecule/opensuse/molecule.yml
+++ b/molecule/opensuse/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-golang-opensuse
-    image: opensuse/leap:15.5
+    image: opensuse/tumbleweed
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Leap defaults to Python 3.6, which is too old for recent Ansible versions.