### PR TITLE
Dropped support for Debian Buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Buster (10)
             * Bullseye (11)
             * Bookworm (12)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,6 @@ galaxy_info:
         - noble
     - name: Debian
       versions:
-        - buster
         - bullseye
         - bookworm
     - name: Fedora

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-golang-debian-min
-    image: debian:10
+    image: debian:11
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian standard support ended on 30 Jun 2025.