### PR TITLE
Updated Go to 1.23.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ are shown below):
 
 ```yaml
 # Go language SDK version number
-golang_version: '1.22.7'
+golang_version: '1.23.3'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'
@@ -73,6 +73,12 @@ The following versions of Go language SDK are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `1.23.3`
+* `1.23.2`
+* `1.23.1`
+* `1.23.0`
+* `1.22.9`
+* `1.22.8`
 * `1.22.7`
 * `1.22.6`
 * `1.22.5`
@@ -252,6 +258,7 @@ instructions):
 * `1.10.2`
 * `1.10.1`
 * `1.10`
+* `1.9.7`
 * `1.9.6`
 * `1.9.5`
 * `1.9.4`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
 # Go language SDK version number
-golang_version: '1.22.7'
+golang_version: '1.23.3'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.22.7$'),
+    ('GOROOT', '^/opt/go/1.23.3$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.22.7/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.23.3/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/molecule/ubuntu-max-go-eol/converge.yml
+++ b/molecule/ubuntu-max-go-eol/converge.yml
@@ -5,5 +5,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.21.13'
+      golang_version: '1.22.9'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.21.13$'),
+    ('GOROOT', '^/opt/go/1.22.9$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.21.13/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.22.9/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.22.8-amd64.yml
+++ b/vars/versions/1.22.8-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5f467d29fc67c7ae6468cb6ad5b047a274bae8180cac5e0b7ddbfeba3e47e18f'

--- a/vars/versions/1.22.8-arm64.yml
+++ b/vars/versions/1.22.8-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5c616b32dab04bb8c4c8700478381daea0174dc70083e4026321163879278a4a'

--- a/vars/versions/1.22.8-armv6l.yml
+++ b/vars/versions/1.22.8-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5191e87a51a85d88edddc028ab30dfbfa2d7c37cf35d536655e7a063bfb2c9d2'

--- a/vars/versions/1.22.9-amd64.yml
+++ b/vars/versions/1.22.9-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '84a8f05b7b969d8acfcaf194ce9298ad5d3ddbfc7034930c280006b5c85a574c'

--- a/vars/versions/1.22.9-arm64.yml
+++ b/vars/versions/1.22.9-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5beec5ef9f019e1779727ef0d9643fa8bf2495e7222014d2fc4fbfce5999bf01'

--- a/vars/versions/1.22.9-armv6l.yml
+++ b/vars/versions/1.22.9-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'ae3651ba40b3b1ec615b01ff9091734b25f7ff3dc9c5b9fb0a261d7a33e00215'

--- a/vars/versions/1.23.0-amd64.yml
+++ b/vars/versions/1.23.0-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3'

--- a/vars/versions/1.23.0-arm64.yml
+++ b/vars/versions/1.23.0-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '62788056693009bcf7020eedc778cdd1781941c6145eab7688bd087bce0f8659'

--- a/vars/versions/1.23.0-armv6l.yml
+++ b/vars/versions/1.23.0-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '0efa1338e644d7f74064fa7f1016b5da7872b2df0070ea3b56e4fef63192e35b'

--- a/vars/versions/1.23.1-amd64.yml
+++ b/vars/versions/1.23.1-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd'

--- a/vars/versions/1.23.1-arm64.yml
+++ b/vars/versions/1.23.1-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'faec7f7f8ae53fda0f3d408f52182d942cc89ef5b7d3d9f23ff117437d4b2d2f'

--- a/vars/versions/1.23.1-armv6l.yml
+++ b/vars/versions/1.23.1-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '6c7832c7dcd8fb6d4eb308f672a725393403c74ee7be1aeccd8a443015df99de'

--- a/vars/versions/1.23.2-amd64.yml
+++ b/vars/versions/1.23.2-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e'

--- a/vars/versions/1.23.2-arm64.yml
+++ b/vars/versions/1.23.2-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'f626cdd92fc21a88b31c1251f419c17782933a42903db87a174ce74eeecc66a9'

--- a/vars/versions/1.23.2-armv6l.yml
+++ b/vars/versions/1.23.2-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'e3286bdde186077e65e961cbe18874d42a461e5b9c472c26572b8d4a98d15c40'

--- a/vars/versions/1.23.3-amd64.yml
+++ b/vars/versions/1.23.3-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8'

--- a/vars/versions/1.23.3-arm64.yml
+++ b/vars/versions/1.23.3-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '1f7cbd7f668ea32a107ecd41b6488aaee1f5d77a66efd885b175494439d4e1ce'

--- a/vars/versions/1.23.3-armv6l.yml
+++ b/vars/versions/1.23.3-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5f0332754beffc65af65a7b2da76e9dd997567d0d81b6f4f71d3588dc7b4cb00'


### PR DESCRIPTION
1.23.3 will now be installed by default.

Support for the following versions has also been added:
* `1.23.2`
* `1.23.1`
* `1.23.0`
* `1.22.9`
* `1.22.8`