### PR TITLE
Updated Go to 1.23.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ are shown below):
 
 ```yaml
 # Go language SDK version number
-golang_version: '1.23.3'
+golang_version: '1.23.5'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'
@@ -73,10 +73,14 @@ The following versions of Go language SDK are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `1.23.5`
+* `1.23.4`
 * `1.23.3`
 * `1.23.2`
 * `1.23.1`
 * `1.23.0`
+* `1.22.11`
+* `1.22.10`
 * `1.22.9`
 * `1.22.8`
 * `1.22.7`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
 # Go language SDK version number
-golang_version: '1.23.3'
+golang_version: '1.23.5'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.23.3$'),
+    ('GOROOT', '^/opt/go/1.23.5$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.23.3/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.23.5/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/molecule/ubuntu-max-go-eol/converge.yml
+++ b/molecule/ubuntu-max-go-eol/converge.yml
@@ -5,5 +5,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.22.9'
+      golang_version: '1.22.11'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.22.9$'),
+    ('GOROOT', '^/opt/go/1.22.11$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.22.9/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.22.11/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.22.10-amd64.yml
+++ b/vars/versions/1.22.10-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '736ce492a19d756a92719a6121226087ccd91b652ed5caec40ad6dbfb2252092'

--- a/vars/versions/1.22.10-arm64.yml
+++ b/vars/versions/1.22.10-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5213c5e32fde3bd7da65516467b7ffbfe40d2bb5a5f58105e387eef450583eec'

--- a/vars/versions/1.22.10-armv6l.yml
+++ b/vars/versions/1.22.10-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'a7bbbc80fe736269820bbdf3555e91ada5d18a5cde2276aac3b559bc1d52fc70'

--- a/vars/versions/1.22.11-amd64.yml
+++ b/vars/versions/1.22.11-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '0fc88d966d33896384fbde56e9a8d80a305dc17a9f48f1832e061724b1719991'

--- a/vars/versions/1.22.11-arm64.yml
+++ b/vars/versions/1.22.11-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '9ebfcab26801fa4cf0627c6439db7a4da4d3c6766142a3dd83508240e4f21031'

--- a/vars/versions/1.22.11-armv6l.yml
+++ b/vars/versions/1.22.11-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'ac3ba3e0433d96b041f683e9bbb791ca39e159b3d4bb948de4ab3a2c1af1b257'

--- a/vars/versions/1.23.4-amd64.yml
+++ b/vars/versions/1.23.4-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '6924efde5de86fe277676e929dc9917d466efa02fb934197bc2eba35d5680971'

--- a/vars/versions/1.23.4-arm64.yml
+++ b/vars/versions/1.23.4-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '16e5017863a7f6071363782b1b8042eb12c6ca4f4cd71528b2123f0a1275b13e'

--- a/vars/versions/1.23.4-armv6l.yml
+++ b/vars/versions/1.23.4-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '1f1dda0dc7ce0b2295f57258ec5ef0803fd31b9ed0aa20e2e9222334e5755de1'

--- a/vars/versions/1.23.5-amd64.yml
+++ b/vars/versions/1.23.5-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'cbcad4a6482107c7c7926df1608106c189417163428200ce357695cc7e01d091'

--- a/vars/versions/1.23.5-arm64.yml
+++ b/vars/versions/1.23.5-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '47c84d332123883653b70da2db7dd57d2a865921ba4724efcdf56b5da7021db0'

--- a/vars/versions/1.23.5-armv6l.yml
+++ b/vars/versions/1.23.5-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '04e0b5cf5c216f0aa1bf8204d49312ad0845800ab0702dfe4357c0b1241027a3'


### PR DESCRIPTION
1.23.5 will now be installed by default.

Support for the following versions has also been added:
* `1.23.4`
* `1.22.11`
* `1.22.10`