### PR TITLE
Updated Go to 1.24.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ are shown below):
 
 ```yaml
 # Go language SDK version number
-golang_version: '1.23.5'
+golang_version: '1.24.2'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'
@@ -73,8 +73,11 @@ The following versions of Go language SDK are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `1.24.2`
 * `1.24.1`
 * `1.24.0`
+* `1.23.8`
+* `1.23.7`
 * `1.23.6`
 * `1.23.5`
 * `1.23.4`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
 # Go language SDK version number
-golang_version: '1.24.1'
+golang_version: '1.24.2'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.24.1$'),
+    ('GOROOT', '^/opt/go/1.24.2$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.24.1/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.24.2/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/molecule/ubuntu-max-go-eol/converge.yml
+++ b/molecule/ubuntu-max-go-eol/converge.yml
@@ -5,5 +5,5 @@
 
   roles:
     - role: ansible-role-golang
-      golang_version: '1.22.11'
+      golang_version: '1.23.8'
       golang_gopath: '$HOME/workspace-go'

--- a/molecule/ubuntu-max-go-eol/tests/test_role.py
+++ b/molecule/ubuntu-max-go-eol/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.22.11$'),
+    ('GOROOT', '^/opt/go/1.23.8$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.22.11/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.23.8/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.23.7-amd64.yml
+++ b/vars/versions/1.23.7-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '4741525e69841f2e22f9992af25df0c1112b07501f61f741c12c6389fcb119f3'

--- a/vars/versions/1.23.7-arm64.yml
+++ b/vars/versions/1.23.7-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '597acbd0505250d4d98c4c83adf201562a8c812cbcd7b341689a07087a87a541'

--- a/vars/versions/1.23.7-armv6l.yml
+++ b/vars/versions/1.23.7-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'c9e9ecd6a8cf1429f1c65d81115c450258258ac65833d95a82d5f4e5ad7d2d7a'

--- a/vars/versions/1.23.8-amd64.yml
+++ b/vars/versions/1.23.8-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '45b87381172a58d62c977f27c4683c8681ef36580abecd14fd124d24ca306d3f'

--- a/vars/versions/1.23.8-arm64.yml
+++ b/vars/versions/1.23.8-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '9d6d938422724a954832d6f806d397cf85ccfde8c581c201673e50e634fdc992'

--- a/vars/versions/1.23.8-armv6l.yml
+++ b/vars/versions/1.23.8-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'd14e0bea9fb25344a0460f395880d5589bbcd413ffd5555be48e46c0de084437'

--- a/vars/versions/1.24.2-amd64.yml
+++ b/vars/versions/1.24.2-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad'

--- a/vars/versions/1.24.2-arm64.yml
+++ b/vars/versions/1.24.2-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '756274ea4b68fa5535eb9fe2559889287d725a8da63c6aae4d5f23778c229f4b'

--- a/vars/versions/1.24.2-armv6l.yml
+++ b/vars/versions/1.24.2-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '438d5d3d7dcb239b58d893a715672eabe670b9730b1fd1c8fc858a46722a598a'


### PR DESCRIPTION
1.24.2 will now be installed by default.

Support for the following versions has also been added:
* `1.23.8`
* `1.23.7`