### PR TITLE
Add go 1.24.3->1.25.3 (sets default to 1.25.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ The following versions of Go language SDK are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `1.25.3`
+* `1.25.2`
+* `1.25.1`
+* `1.25.0`
+* `1.24.9`
+* `1.24.8`
+* `1.24.7`
+* `1.24.6`
+* `1.24.5`
+* `1.24.4`
+* `1.24.3`
 * `1.24.2`
 * `1.24.1`
 * `1.24.0`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # code: language=ansible
 ---
 # Go language SDK version number
-golang_version: '1.24.2'
+golang_version: '1.25.3'
 
 # Mirror to download the Go language SDK redistributable package from
 golang_mirror: 'https://storage.googleapis.com/golang'

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -3,9 +3,9 @@ import re
 
 
 @pytest.mark.parametrize('name,pattern', [
-    ('GOROOT', '^/opt/go/1.24.2$'),
+    ('GOROOT', '^/opt/go/1.25.3$'),
     ('GOPATH', '^/root/workspace-go$'),
-    ('PATH', '^(.+:)?/opt/go/1.24.2/bin(:.+)?$'),
+    ('PATH', '^(.+:)?/opt/go/1.25.3/bin(:.+)?$'),
     ('PATH', '^(.+:)?/root/workspace-go/bin(:.+)?$')
 ])
 def test_go_env(host, name, pattern):

--- a/vars/versions/1.24.3-amd64.yml
+++ b/vars/versions/1.24.3-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8'

--- a/vars/versions/1.24.3-arm64.yml
+++ b/vars/versions/1.24.3-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'a463cb59382bd7ae7d8f4c68846e73c4d589f223c589ac76871b66811ded7836'

--- a/vars/versions/1.24.3-armv6l.yml
+++ b/vars/versions/1.24.3-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '17a392d7e826625dd12a32099df0b00b85c32d8132ed86fe917183ee5c3f88ed'

--- a/vars/versions/1.24.4-amd64.yml
+++ b/vars/versions/1.24.4-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717'

--- a/vars/versions/1.24.4-arm64.yml
+++ b/vars/versions/1.24.4-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'd5501ee5aca0f258d5fe9bfaed401958445014495dc115f202d43d5210b45241'

--- a/vars/versions/1.24.4-armv6l.yml
+++ b/vars/versions/1.24.4-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '6a554e32301cecae3162677e66d4264b81b3b1a89592dd1b7b5c552c7a49fe37'

--- a/vars/versions/1.24.5-amd64.yml
+++ b/vars/versions/1.24.5-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '10ad9e86233e74c0f6590fe5426895de6bf388964210eac34a6d83f38918ecdc'

--- a/vars/versions/1.24.5-arm64.yml
+++ b/vars/versions/1.24.5-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '0df02e6aeb3d3c06c95ff201d575907c736d6c62cfa4b6934c11203f1d600ffa'

--- a/vars/versions/1.24.5-armv6l.yml
+++ b/vars/versions/1.24.5-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'dc043c10cfa60e82687ab2a671d500de1f210042021bc3bca43dfb4fa6bfeca7'

--- a/vars/versions/1.24.6-amd64.yml
+++ b/vars/versions/1.24.6-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712'

--- a/vars/versions/1.24.6-arm64.yml
+++ b/vars/versions/1.24.6-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '124ea6033a8bf98aa9fbab53e58d134905262d45a022af3a90b73320f3c3afd5'

--- a/vars/versions/1.24.6-armv6l.yml
+++ b/vars/versions/1.24.6-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '7feb4d25f5e72f94fda81c99d4adb6630dfa2c35211e0819417d53af6e71809e'

--- a/vars/versions/1.24.7-amd64.yml
+++ b/vars/versions/1.24.7-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'da18191ddb7db8a9339816f3e2b54bdded8047cdc2a5d67059478f8d1595c43f'

--- a/vars/versions/1.24.7-arm64.yml
+++ b/vars/versions/1.24.7-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'fd2bccce882e29369f56c86487663bb78ba7ea9e02188a5b0269303a0c3d33ab'

--- a/vars/versions/1.24.7-armv6l.yml
+++ b/vars/versions/1.24.7-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'eaff4aace921075da371b91a5911f0c0fbcb6f712a527a25113f971944b78c36'

--- a/vars/versions/1.24.8-amd64.yml
+++ b/vars/versions/1.24.8-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '6842c516ca66c89d648a7f1dbe28e28c47b61b59f8f06633eb2ceb1188e9251d'

--- a/vars/versions/1.24.8-arm64.yml
+++ b/vars/versions/1.24.8-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '38ac33b4cfa41e8a32132de7a87c6db49277ab5c0de1412512484db1ed77637e'

--- a/vars/versions/1.24.8-armv6l.yml
+++ b/vars/versions/1.24.8-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '3ed8537300ab22449885a43d2931336a571df72c5433d2db4377fe7e2d5e83db'

--- a/vars/versions/1.24.9-amd64.yml
+++ b/vars/versions/1.24.9-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '5b7899591c2dd6e9da1809fde4a2fad842c45d3f6b9deb235ba82216e31e34a6'

--- a/vars/versions/1.24.9-arm64.yml
+++ b/vars/versions/1.24.9-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '9aa1243d51d41e2f93e895c89c0a2daf7166768c4a4c3ac79db81029d295a540'

--- a/vars/versions/1.24.9-armv6l.yml
+++ b/vars/versions/1.24.9-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '39dafc8e7e5e455995f87e1ffc6b0892302ea519c1f0e59c9e2e0fda41b8aa56'

--- a/vars/versions/1.25.0-amd64.yml
+++ b/vars/versions/1.25.0-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613'

--- a/vars/versions/1.25.0-arm64.yml
+++ b/vars/versions/1.25.0-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '05de75d6994a2783699815ee553bd5a9327d8b79991de36e38b66862782f54ae'

--- a/vars/versions/1.25.0-armv6l.yml
+++ b/vars/versions/1.25.0-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'a5a8f8198fcf00e1e485b8ecef9ee020778bf32a408a4e8873371bfce458cd09'

--- a/vars/versions/1.25.1-amd64.yml
+++ b/vars/versions/1.25.1-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '7716a0d940a0f6ae8e1f3b3f4f36299dc53e31b16840dbd171254312c41ca12e'

--- a/vars/versions/1.25.1-arm64.yml
+++ b/vars/versions/1.25.1-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '65a3e34fb2126f55b34e1edfc709121660e1be2dee6bdf405fc399a63a95a87d'

--- a/vars/versions/1.25.1-armv6l.yml
+++ b/vars/versions/1.25.1-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'eb949be683e82a99e9861dafd7057e31ea40b161eae6c4cd18fdc0e8c4ae6225'

--- a/vars/versions/1.25.2-amd64.yml
+++ b/vars/versions/1.25.2-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: 'd7fa7f8fbd16263aa2501d681b11f972a5fd8e811f7b10cb9b26d031a3d7454b'

--- a/vars/versions/1.25.2-arm64.yml
+++ b/vars/versions/1.25.2-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '9aaeb044bf8dbf50ca2fbf0edc5ebc98b90d5bda8c6b2911526df76f61232919'

--- a/vars/versions/1.25.2-armv6l.yml
+++ b/vars/versions/1.25.2-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '63572d476f02c1f1049e11c42cb2017eb7b241187e219a004e83202a4a17d21e'

--- a/vars/versions/1.25.3-amd64.yml
+++ b/vars/versions/1.25.3-amd64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f'

--- a/vars/versions/1.25.3-arm64.yml
+++ b/vars/versions/1.25.3-arm64.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '1d42ebc84999b5e2069f5e31b67d6fc5d67308adad3e178d5a2ee2c9ff2001f5'

--- a/vars/versions/1.25.3-armv6l.yml
+++ b/vars/versions/1.25.3-armv6l.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+golang_redis_sha256sum: '3992bd28316484be0af36494124588581aa27e0659a436d607b11d534045bc1f'


### PR DESCRIPTION
* Sets default version to be `1.25.3`
* Adds support for the following versions:
  * 1.24.3
  * 1.24.4
  * 1.24.5
  * 1.24.6
  * 1.24.7
  * 1.24.8
  * 1.24.9
  * 1.25.0
  * 1.25.1
  * 1.25.2
  * 1.25.3